### PR TITLE
Fixing counts for Nomad

### DIFF
--- a/tests/nomad/main.go
+++ b/tests/nomad/main.go
@@ -250,28 +250,18 @@ ALLOC_POLL:
 
 // timeToCumCount returns a mapping of time to cumulative counts
 // {foo: 10, bar: 20} -> {10: 1, 20:2}
-func timeToCumCount(in map[string]int64) map[int64]int64 {
-	out := make(map[int64]int64)
-	intermediate := make(map[int]int64)
-	for _, v := range in {
-		intermediate[int(v)] += 1
-	}
+func timeToCumCount(in map[string]int64) map[int64]int {
+	out := make(map[int64]int, len(in))
 
-	var times []int
-	for time := range intermediate {
+	times := make([]int64, 0, len(in))
+	for _, time := range in {
 		times = append(times, time)
 	}
+	sort.Sort(Int64Sort(times))
 
-	if len(times) == 0 {
-		return out
+	for i, time := range times {
+		out[time] = i + 1
 	}
-
-	sort.Ints(times)
-	out[int64(times[0])] = int64(intermediate[times[0]])
-	for i := 1; i < len(times); i++ {
-		out[int64(times[i])] = int64(out[int64(times[i-1])] + intermediate[times[i]])
-	}
-
 	return out
 }
 
@@ -307,6 +297,21 @@ func convertStructJob(in *structs.Job) (*api.Job, error) {
 		return nil, err
 	}
 	return apiJob, nil
+}
+
+// Int64Sort is used to sort slices of int64 numbers
+type Int64Sort []int64
+
+func (s Int64Sort) Len() int {
+	return len(s)
+}
+
+func (s Int64Sort) Less(a, b int) bool {
+	return s[a] < s[b]
+}
+
+func (s Int64Sort) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
 }
 
 const usage = `


### PR DESCRIPTION
I read this wrong in the original PR, and I think this is actually what we need. We were losing resolution by using an `int`, so by using `int64` we have to add a sorter for it, but it makes the method more simple.

/cc @dadgar for a logic check
